### PR TITLE
Fix business hours message

### DIFF
--- a/bot/line.ts
+++ b/bot/line.ts
@@ -37,7 +37,8 @@ const monthlyScheduleMessage = () => {
   const thisMonth = now.getMonth() + 1;
 
   const monthlySchedules = schedules[thisYear][thisMonth];
-  let message = `[今月の鼻毛]\n ${businessHours}\n\n`;
+
+  let message = "[今月の鼻毛]\n";
   monthlySchedules.forEach((schedule, index) => {
     message = message.concat(
       `📅${schedule.from} ~ ${schedule.to}\n🚃${schedule.station.name}\n`,
@@ -47,6 +48,8 @@ const monthlyScheduleMessage = () => {
       message = message.concat("\n");
     }
   });
+
+  message = message.concat(`[営業時間]\n${businessHours.join("\n")}`);
 
   return message;
 };

--- a/hanage/schedules.ts
+++ b/hanage/schedules.ts
@@ -94,5 +94,8 @@ const schedules: SchedulesOfYear = {
 
 export default schedules;
 
-export const businessHours =
-  "月-金  12:00~20:00  土  11:00~19:00  日･祝  11:00~17:00";
+export const businessHours = [
+  "月-金  12:00~20:00",
+  "土  11:00~19:00",
+  "日･祝  11:00~17:00",
+];


### PR DESCRIPTION
## 修正内容

営業時間のメッセージはスケジュールの後ろに表示するように修正
→デザイン観点の情報アーキテクチャ的には情報の優先度が高い方が先に行くべき(先輩からの教訓)
