### PR TITLE
feat: add June 2023

### DIFF
--- a/hanage/schedules.ts
+++ b/hanage/schedules.ts
@@ -135,6 +135,23 @@ const schedules2023: SchedulesOfMonth = {
       to: "2023-05-31",
     },
   ],
+  6: [
+    {
+      station: stations.bakuroYokoyama,
+      from: "2023-06-01",
+      to: "2023-06-04",
+    },
+    {
+      station: stations.ichigaya,
+      from: "2023-06-05",
+      to: "2023-06-11",
+    },
+    {
+      station: stations.shinjukuSanchome,
+      from: "2023-06-12",
+      to: "2023-06-18",
+    },
+  ],
 };
 
 const schedules: SchedulesOfYear = {


### PR DESCRIPTION
## Description 

Add schedule on June 2023 

```sh
[6月の鼻毛]
📅2023-06-01 ~ 2023-06-04
🚃馬喰横山駅

📅2023-06-05 ~ 2023-06-11
🚃市ヶ谷駅

📅2023-06-12 ~ 2023-06-18
🚃新宿三丁目駅

[営業時間]
月-金  12:00~20:00
土  11:00~19:00
日･祝  11:00~17:00
```

## Reference

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/28638961/236729616-bf5502bf-ddb1-417e-8964-0de23610396e.png">

